### PR TITLE
Fix empty host

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -52,7 +52,7 @@ func (c *Client) ChatWithContext(ctx context.Context, in *ChatRequest) (*ChatRes
 
 	reqBytes, _ := json.Marshal(in)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ChatPath, bytes.NewReader(reqBytes))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.config.BaseUrl+ChatPath, bytes.NewReader(reqBytes))
 	if err != nil {
 		return nil, err
 	}

--- a/model.go
+++ b/model.go
@@ -23,7 +23,7 @@ func (c *Client) Models() (*ModelListResponse, error) {
 
 func (c *Client) ModelsWithContext(ctx context.Context) (*ModelListResponse, error) {
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ModelsPath, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.config.BaseUrl+ModelsPath, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
At the moment, `Models()` and `ChatWithContext()` do not set Host.

Example:
```package main

import (
	"fmt"
	"github.com/paulrzcz/go-gigachat"
)

func main() {
	client, err := gigachat.NewInsecureClient("<clientId>", "<clientSecret>")
	if err != nil {
		fmt.Println(err)
		return
	}

	err = client.Auth()
	if err != nil {
		fmt.Println(err)
		return
	}

	models, err := client.Models()
	if err != nil {
		fmt.Println(err)
		return
	}

	fmt.Println(models)

}
```

Current output:
`Get "v1/models": unsupported protocol scheme ""`

Expected output:
`&{[{GigaChat model salutedevices} {GigaChat-Plus model salutedevices} {GigaChat-Plus-preview model salutedevices} {GigaChat-Pro model salutedevices} {GigaChat-Pro-preview model salutedevices} {GigaChat-preview model salutedevices}] list}`